### PR TITLE
Minor fix in promises.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,17 @@
 __OLD__
 /node_modules
 working.js
+
+## IDEA ignores
+.idea/
+*.iml
+
+## Miscellaneous ignores
+*.DS_STORE
+*~
+*.tmp
+*.tar.gz
+*.tar
+*.tgz
+*.zip
+*.rar

--- a/node/promises.md
+++ b/node/promises.md
@@ -118,8 +118,6 @@ One of the nice things about Promises is that if we add a `then` handler _after_
 
 ```js
 let promise = Promise.resolve("done");
-
-let promise = Promise.resolve("done");
 promise.then(val => console.log(val)); // 'done'
 ```
 


### PR DESCRIPTION
Variable `promise` is declared twice in `node/promises.js`, this will cause the following error:
```bash
let promise = Promise.resolve("done");
    ^

SyntaxError: Identifier 'promise' has already been declared
    at new Script (vm.js:80:7)
    at createScript (vm.js:274:10)
    at Object.runInThisContext (vm.js:326:10)
    at Module._compile (internal/modules/cjs/loader.js:664:28)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:712:10)
    at Module.load (internal/modules/cjs/loader.js:600:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:539:12)
    at Function.Module._load (internal/modules/cjs/loader.js:531:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:754:12)
    at startup (internal/bootstrap/node.js:283:19)
```

Additionally, I've extended `.gitingore` so that my extraneous files are not dragged into the commits.